### PR TITLE
Normalize and encode as ascii when an Unicode error occurs.

### DIFF
--- a/siem.py
+++ b/siem.py
@@ -32,6 +32,7 @@ import re
 import socket
 import time
 import urllib2
+import unicodedata
 from optparse import OptionParser
 from random import randint
 
@@ -464,7 +465,11 @@ def format_prefix(data):
 def format_extension(data):
     # equal sign and backslash in extension value must be escaped
     # escape group with backslash
-    return EXTENSION_PATTERN.sub(r'\\\1', data)
+    try:
+        return EXTENSION_PATTERN.sub(r'\\\1', data)
+    except UnicodeEncodeError as e:
+        data = unicodedata.normalize('NFKD', data).encode('ascii','ignore')
+        return EXTENSION_PATTERN.sub(r'\\\1', data)
 
 
 def map_severity(severity):


### PR DESCRIPTION
Ex:

```
URL: https://api4.central.sophos.com/gateway/siem/v1/events?from_date=1484801456&limit=1000
Traceback (most recent call last):
  File "siem.py", line 538, in <module>
    main()
  File "siem.py", line 210, in main
    process_endpoint(endpoint, opener, endpoint_config, creds)
  File "siem.py", line 268, in process_endpoint
    write_cef_format(results, siem_logger)
  File "siem.py", line 317, in write_cef_format
    siem_logger.info(format_cef(flatten_json(i)) + u'\n')
  File "siem.py", line 526, in format_cef
    value = format_extension(value)
  File "siem.py", line 470, in format_extension
    return EXTENSION_PATTERN.sub(r'\\\1', str(data))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2019' in position 6: ordinal not in range(128)
```

We encountered this error while processing some events and the computer name was something like "Bob's Laptop".
