### PR TITLE
Add delay in the data collection to avoid missing events issue.

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -36,3 +36,7 @@ socktype = udp
 
 # cache file full or relative path (with a ".json" extension)
 state_file_path = state/siem_sophos.json
+
+# Delay the data collection by X seconds to avoid events missing issue from Sophos API
+# The issue could be due to some specific host being ahead in time for a few seconds and Sophos Central would consider events received from that host as a checkpoint.
+collection_delay = 60


### PR DESCRIPTION
Adding extra delay while collecting the events/alerts from Sophos central API. 
The delay is configurable through the config file. The default is 60 seconds.

Story:
- I was seeing many events being missed on Splunk so I started investigating the issue and it seems when I tried to execute the script again I was seeing the events.
- So, I think this behavior could be due to some specific host being ahead in time for a few seconds, and Sophos Central would consider events received from that host as a checkpoint when returning the response.
- Hence you may miss some events from other hosts which are behind in time from that host which registered the new checkpoint.