### PR TITLE
Add a new jsonarray format for single use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This release adds a new output format, `non-streamed-json`. This outputs the alerts and events as an array of json objects. 
 This allows the file to be read by tools that expect the file to be a single json object (such as MS Excel import JSON data), 
-rather than the Newline Delimited JSON format created using the standard `json` output format, designed for Streaming 
+rather than the JSON Lines (aka Newline Delimited JSON) format created using the default `json` output format, designed for Streamed 
 JSON parsers, used by logging services, such as Splunk. 
 
 # v2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v2.2.0
 
-This release adds a new output format, `non-streamed-json`. This outputs the alerts and events as an array of json objects. 
+This release adds a new output format, `jsonarray`. This outputs the alerts and events as an array of json objects. 
 This allows the file to be read by tools that expect the file to be a single json object (such as MS Excel import JSON data), 
-rather than the JSON Lines (aka Newline Delimited JSON) format created using the default `json` output format, designed for Streamed 
+rather than the JSON Lines (aka Newline Delimited JSON or jsonl) format created using the default `json` output format, designed for Streamed 
 JSON parsers, used by logging services, such as Splunk. 
 
 # v2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v2.2.0
+
+This release adds a new output format, `non-streamed-json`. This outputs the alerts and events as an array of json objects. 
+This allows the file to be read by tools that expect the file to be a single json object (such as MS Excel import JSON data), 
+rather than the Newline Delimited JSON format created using the standard `json` output format, designed for Streaming 
+JSON parsers, used by logging services, such as Splunk. 
+
 # v2.1.0
 
 This release contains the following fixes:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ config.ini is a configuration file that exists by default in the siem-scripts fo
 
 ##### Optional configuration steps:
 
-1. Under json, cef or keyvalue, you could choose the preferred output of the response i.e. json, cef or keyvalue.
+1. Under json, cef or keyvalue, you could choose the preferred output of the response i.e. json, cef, keyvalue or non-streamed-json.
+   1. json format is designed for Newline-Delimited JSON, a Streamed JSON format used by logging systems such as Splunk, where each new line is a separate json object.
+   2. non-streamed-json format is designed to output the entire output as an array, where the entire file can be loaded by a tool that expects the entire file to be one single array, such as the import JSON function in MS Excel.
 2. Under filename, you can specify the filename that your output would be saved to. Options are syslog, stdout or any custom file name. Custom files are created in a folder named log.
 3. If you are using syslog then under syslog properties in the config file, configure address, facility and socktype.
 4. under state_file_path, specify the full or relative path to the cache file (with a ".json" extension)
@@ -102,7 +104,7 @@ Run `python siem.py` and you should see the results as specified in the config f
 
 ### License
 
-Copyright 2016-2021 Sophos Limited
+Copyright 2016-2023 Sophos Limited
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 You may obtain a copy of the License at: [LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ config.ini is a configuration file that exists by default in the siem-scripts fo
 ##### Optional configuration steps:
 
 1. Under json, cef or keyvalue, you could choose the preferred output of the response i.e. json, cef, keyvalue or non-streamed-json.
-   1. json format is designed for Newline-Delimited JSON, a Streamed JSON format used by logging systems such as Splunk, where each new line is a separate json object.
+   1. json format is designed for JSON Lines format (aka Newline Delimited JSON). This is a Streamed JSON format, designed to be imported into logging services, such as Splunk; where each line is a separate json object.
    2. non-streamed-json format is designed to output the entire output as an array, where the entire file can be loaded by a tool that expects the entire file to be one single array, such as the import JSON function in MS Excel.
 2. Under filename, you can specify the filename that your output would be saved to. Options are syslog, stdout or any custom file name. Custom files are created in a folder named log.
 3. If you are using syslog then under syslog properties in the config file, configure address, facility and socktype.

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ config.ini is a configuration file that exists by default in the siem-scripts fo
 
 ##### Optional configuration steps:
 
-1. Under `format`, you could choose the preferred output of the response i.e. `json`, `cef`, `keyvalue` or `non-streamed-json`.
+1. Under `format`, you could choose the preferred output of the response i.e. `json`, `cef`, `keyvalue` or `jsonarray`.
    1. `json` format is designed for JSON Lines format (aka Newline Delimited JSON). This is a Streamed JSON format, designed to be imported into logging services, such as Splunk; where each line is a separate json object.
-   2. `non-streamed-json` format is designed to output the entire output as an array, where the entire file can be loaded by a tool that expects the entire file to be one single array, such as the import JSON function in MS Excel. `non-streamed-json`, by its very nature, is not designed to be appended to. When using this format the output file (`result.txt`) should be cleared down/renamed before each run. `json` format should be used when using `syslog` configuration.
+   2. `jsonarray` format is designed to output the entire output as an array, where the entire file can be loaded by a tool that expects the entire file to be one single array, such as the import JSON function in MS Excel. `jsonarray`, by its very nature, is not designed to be appended to. When using this format the output file (`result.txt`) should be cleared down/renamed before each run. `json` format should be used when using `syslog` configuration.
 2. Under `filename`, you can specify the filename that your output would be saved to. Options are syslog, stdout or any custom file name. Custom files are created in a folder named log.
 3. If you are using syslog then under `# syslog properties` in the config file, configure `address`, `facility` and `socktype`.
 4. under `state_file_path`, specify the full or relative path to the cache file (with a ".json" extension)

--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ config.ini is a configuration file that exists by default in the siem-scripts fo
 
 ##### Optional configuration steps:
 
-1. Under json, cef or keyvalue, you could choose the preferred output of the response i.e. json, cef, keyvalue or non-streamed-json.
-   1. json format is designed for JSON Lines format (aka Newline Delimited JSON). This is a Streamed JSON format, designed to be imported into logging services, such as Splunk; where each line is a separate json object.
-   2. non-streamed-json format is designed to output the entire output as an array, where the entire file can be loaded by a tool that expects the entire file to be one single array, such as the import JSON function in MS Excel.
-2. Under filename, you can specify the filename that your output would be saved to. Options are syslog, stdout or any custom file name. Custom files are created in a folder named log.
-3. If you are using syslog then under syslog properties in the config file, configure address, facility and socktype.
-4. under state_file_path, specify the full or relative path to the cache file (with a ".json" extension)
+1. Under `format`, you could choose the preferred output of the response i.e. `json`, `cef`, `keyvalue` or `non-streamed-json`.
+   1. `json` format is designed for JSON Lines format (aka Newline Delimited JSON). This is a Streamed JSON format, designed to be imported into logging services, such as Splunk; where each line is a separate json object.
+   2. `non-streamed-json` format is designed to output the entire output as an array, where the entire file can be loaded by a tool that expects the entire file to be one single array, such as the import JSON function in MS Excel. `non-streamed-json`, by its very nature, is not designed to be appended to. When using this format the output file (`result.txt`) should be cleared down/renamed before each run. `json` format should be used when using `syslog` configuration.
+2. Under `filename`, you can specify the filename that your output would be saved to. Options are syslog, stdout or any custom file name. Custom files are created in a folder named log.
+3. If you are using syslog then under `# syslog properties` in the config file, configure `address`, `facility` and `socktype`.
+4. under `state_file_path`, specify the full or relative path to the cache file (with a ".json" extension)
 
 
 ### Running the script

--- a/api_client.py
+++ b/api_client.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2019-2021 Sophos Limited
+# Copyright 2019-2023 Sophos Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
 # compliance with the License.
@@ -414,7 +414,7 @@ class ApiClient:
         Returns:
             dict -- response containing either list of tenant or error
         """
-        self.log("Fetching the tenants/customers list by calling the Sophos Cental API")
+        self.log("Fetching the tenants/customers list by calling the Sophos Central API")
         response = self.get_sophos_jwt()
 
         if "access_token" in response:

--- a/config.ini
+++ b/config.ini
@@ -17,7 +17,7 @@ auth_url = https://id.sophos.com/api/v2/oauth2/token
 # whoami API host url
 api_host = api.central.sophos.com
 
-# format can be json, cef, keyvalue or non-streamed-json
+# format can be json, cef, keyvalue or jsonarray
 format = json
 
 # filename can be syslog, stdout, any custom filename

--- a/config.ini
+++ b/config.ini
@@ -17,7 +17,7 @@ auth_url = https://id.sophos.com/api/v2/oauth2/token
 # whoami API host url
 api_host = api.central.sophos.com
 
-# format can be json, cef or keyvalue
+# format can be json, cef, keyvalue or non-streamed-json
 format = json
 
 # filename can be syslog, stdout, any custom filename

--- a/siem.py
+++ b/siem.py
@@ -91,8 +91,8 @@ def write_json_format(results, config):
         SIEM_LOGGER.info(json.dumps(i, ensure_ascii=False).strip())
 
 
-def write_non_streamed_json_format(results, config):
-    """Write JSON format data.
+def write_json_array_format(results, config):
+    """Write JSON Array format data.
     Arguments:
         results {list}: data
         config {Config}: configuration
@@ -383,7 +383,7 @@ def load_config(config_path):
     return cfg
 
 def validate_format(format):
-    if format not in ("json", "keyvalue", "cef", "non-streamed-json"):
+    if format not in ("json", "keyvalue", "cef", "jsonarray"):
         raise Exception("Invalid format in config.ini, format can be json, cef or keyvalue")
 
 def validate_endpoint(endpoint):
@@ -408,8 +408,8 @@ def get_alerts_or_events(endpoint, options, config, state):
         write_keyvalue_format(results, config)
     elif config.format == "cef":
         write_cef_format(results, config)
-    elif config.format == "non-streamed-json":
-        write_non_streamed_json_format(results, config)
+    elif config.format == "jsonarray":
+        write_json_array_format(results, config)
     else:
         write_json_format(results, config)
 

--- a/siem.py
+++ b/siem.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2019-2021 Sophos Limited
+# Copyright 2019-2023 Sophos Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -89,6 +89,31 @@ def write_json_format(results, config):
         update_cef_keys(i, config)
         name_mapping.update_fields(log, i)
         SIEM_LOGGER.info(json.dumps(i, ensure_ascii=False).strip())
+
+
+def write_non_streamed_json_format(results, config):
+    """Write JSON format data.
+    Arguments:
+        results {list}: data
+        config {Config}: configuration
+    """
+    if not results:
+        SIEM_LOGGER.info("[]")
+        return
+
+    for count, result in enumerate(results):
+        result = remove_null_values(result)
+        update_cef_keys(result, config)
+        name_mapping.update_fields(log, result)
+        if count == 0:
+            prefix = "["
+        else:
+            prefix = ""
+        if count == len(results) - 1:
+            suffix = "]"
+        else:
+            suffix = ","
+        SIEM_LOGGER.info(prefix + json.dumps(result, ensure_ascii=False).strip() + suffix)
 
 
 def write_keyvalue_format(results, config):
@@ -411,4 +436,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-    

--- a/siem.py
+++ b/siem.py
@@ -406,6 +406,8 @@ def get_alerts_or_events(endpoint, options, config, state):
         write_keyvalue_format(results, config)
     elif config.format == "cef":
         write_cef_format(results, config)
+    elif config.format == "non-streamed-json":
+        write_non_streamed_json_format(results, config)
     else:
         write_json_format(results, config)
 

--- a/siem.py
+++ b/siem.py
@@ -381,7 +381,7 @@ def load_config(config_path):
     return cfg
 
 def validate_format(format):
-    if format not in ("json", "keyvalue", "cef"):
+    if format not in ("json", "keyvalue", "cef", "non-streamed-json"):
         raise Exception("Invalid format in config.ini, format can be json, cef or keyvalue")
 
 def validate_endpoint(endpoint):

--- a/siem.py
+++ b/siem.py
@@ -101,7 +101,9 @@ def write_non_streamed_json_format(results, config):
         SIEM_LOGGER.info("[]")
         return
 
-    for count, result in enumerate(results):
+    results_list = list(results)
+
+    for count, result in enumerate(results_list):
         result = remove_null_values(result)
         update_cef_keys(result, config)
         name_mapping.update_fields(log, result)
@@ -109,7 +111,7 @@ def write_non_streamed_json_format(results, config):
             prefix = "["
         else:
             prefix = ""
-        if count == len(results) - 1:
+        if count == len(results_list) - 1:
             suffix = "]"
         else:
             suffix = ","

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Sophos Limited
+# Copyright 2019-2023 Sophos Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
 # compliance with the License.
@@ -20,13 +20,12 @@
 import os
 import shutil
 import api_client
-import sys
 import unittest
 import json
 import time
 
-from mock import MagicMock
-from mock import patch
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 
 class Options:

--- a/tests/unit/test_siem.py
+++ b/tests/unit/test_siem.py
@@ -52,12 +52,12 @@ class TestSiem(unittest.TestCase):
 
     @patch("config.Config")
     @patch("name_mapping.update_fields")
-    def test_write_non_streamed_json_format(self, mock_update_fields, mock_config):
+    def test_write_json_array_format(self, mock_update_fields, mock_config):
         # Setup
         results = [{"key0": "value0"}, {"key1": "value1"}, {"key2": "value2"}]
 
         # Run
-        siem.write_non_streamed_json_format(results, mock_config)
+        siem.write_json_array_format(results, mock_config)
 
         # Verify
         self.assertEqual(mock_update_fields.call_count, 3)
@@ -73,12 +73,12 @@ class TestSiem(unittest.TestCase):
 
     @patch("config.Config")
     @patch("name_mapping.update_fields")
-    def test_write_non_streamed_json_format_single_item(self, mock_update_fields, mock_config):
+    def test_write_json_array_format_single_item(self, mock_update_fields, mock_config):
         # Setup
         results = [{"key0": "value0"}]
 
         # Run
-        siem.write_non_streamed_json_format(results, mock_config)
+        siem.write_json_array_format(results, mock_config)
 
         # Verify
         self.assertEqual(mock_update_fields.call_count, 1)
@@ -88,12 +88,12 @@ class TestSiem(unittest.TestCase):
 
     @patch("config.Config")
     @patch("name_mapping.update_fields")
-    def test_write_non_streamed_json_format_no_items(self, mock_update_fields, mock_config):
+    def test_write_json_array_format_no_items(self, mock_update_fields, mock_config):
         # Setup
         results = []
 
         # Run
-        siem.write_non_streamed_json_format(results, mock_config)
+        siem.write_json_array_format(results, mock_config)
 
         # Verify
         self.assertEqual(mock_update_fields.call_count, 0)

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2019-2021 Sophos Limited
+# Copyright 2019-2023 Sophos Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
 # compliance with the License.
@@ -15,11 +15,10 @@
 import unittest
 import shutil
 import os
-import mock
 import state
-import sys
 from pathlib import Path
 
+from unittest.mock import patch
 
 class Options:
     def __init__(self):
@@ -44,26 +43,26 @@ class TestState(unittest.TestCase):
         self.assertEquals(path.parent.is_dir(), True)
         self.assertEqual(self.state.state_data, {})
 
-    @mock.patch("state.State.get_state_file")
-    @mock.patch("state.State.create_state_dir")
-    @mock.patch("state.State.load_state_file")
-    @mock.patch("sys.stderr.write")
+    @patch("state.State.get_state_file")
+    @patch("state.State.create_state_dir")
+    @patch("state.State.load_state_file")
+    @patch("sys.stderr.write")
     def test_log(self, mock_sys_write, mock_load_file, mock_state_dir, mock_state_file):
         self.state.log("test")
         mock_sys_write.assert_called_once()
         mock_sys_write.assert_called_with("test\n")
 
-    @mock.patch("state.State.create_state_dir")
-    @mock.patch("state.State.load_state_file")
+    @patch("state.State.create_state_dir")
+    @patch("state.State.load_state_file")
     def test_get_state_file_with_empty_state_path(
         self, mock_load_file, mock_state_dir
     ):
         filepath = self.state.get_state_file("/tmp", None)
         self.assertEqual(filepath, "/tmp/state/siem_sophos.json")
 
-    @mock.patch("state.State.get_state_file")
-    @mock.patch("state.State.create_state_dir")
-    @mock.patch("sys.stderr.write")
+    @patch("state.State.get_state_file")
+    @patch("state.State.create_state_dir")
+    @patch("sys.stderr.write")
     def test_load_state_file_io_exception(
         self, mock_sys_write, mock_load_file, mock_state_dir
     ):


### PR DESCRIPTION
Added a new format, non-streamed-json, to support a single run export to non-streamed json (ie: not JSON Lines), to allow the output to be imported to applications that support standard json format, such as MS Excel.